### PR TITLE
fix(default): Ensure Air Boundary modifier is completely invisible

### DIFF
--- a/honeybee_standards/modifiers/default.mat
+++ b/honeybee_standards/modifiers/default.mat
@@ -84,10 +84,10 @@ void plastic generic_ceiling_exterior_side_0.35
 0
 5 0.35 0.35 0.35 0.0 0.0
 
-void glass air_boundary
+void trans air_boundary
 0
 0
-3 1.0 1.0 1.0
+7 1.0 1.0 1.0 0.0 0.0 1.0 1.0
 
 void plastic black
 0

--- a/honeybee_standards/radiance_default.json
+++ b/honeybee_standards/radiance_default.json
@@ -334,14 +334,17 @@
             "dependencies": []
         },
         {
-            "modifier": null,
-            "type": "Glass",
-            "identifier": "air_boundary",
-            "r_transmissivity": 1.0,
-            "g_transmissivity": 1.0,
-            "b_transmissivity": 1.0,
-            "refraction_index": null,
-            "dependencies": []
+            "r_reflectance": 1.0, 
+            "b_reflectance": 1.0, 
+            "roughness": 0.0, 
+            "identifier": "air_boundary", 
+            "type": "Trans", 
+            "dependencies": [], 
+            "g_reflectance": 1.0, 
+            "specularity": 0.0, 
+            "transmitted_diff": 1.0, 
+            "transmitted_spec": 1.0, 
+            "modifier": null
         },
         {
             "modifier": null,


### PR DESCRIPTION
It turns out that a 100% transparent glass material is not completely invisible (possibly because of the refraction). This changes the default to be an invisible trans material as Greg suggests here:

https://www.radiance-online.org/pipermail/radiance-general/2003-September/000998.html