### PR TITLE
fix(energy_default): Generalize the Control TypeLimit to be more useful

### DIFF
--- a/honeybee_standards/energy_default.json
+++ b/honeybee_standards/energy_default.json
@@ -1672,11 +1672,13 @@
         },
         {
             "type": "ScheduleTypeLimit",
-            "identifier": "Thermostat Control", 
-            "upper_limit": 4.0, 
+            "identifier": "Control Level", 
+            "upper_limit": {
+                "type": "NoLimit"
+            }, 
             "lower_limit": 0.0, 
             "numeric_type": "Discrete", 
-            "unit_type": "Dimensionless"
-        }        
+            "unit_type": "Control"
+        }
     ]
 }


### PR DESCRIPTION
I realized that there will probably be a few places where having a typelimit for integers will be useful (the most immediate one is dynamic constructions. So I'm making this change now before the next stable release where we plan to have everyone update their standards anyway.